### PR TITLE
tls: fix timeout via HandshakeContext

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -77,7 +77,7 @@ func (d *dialer) DialWithProxy(protocol, addr, proxyURL string, timeout time.Dur
 		return nil, fmt.Errorf("proxy error: %w", err)
 	}
 	if protocol == "https" {
-		if c, err = TlsHandshake(c, addr); err != nil {
+		if c, err = TlsHandshake(c, addr, timeout); err != nil {
 			return nil, fmt.Errorf("tls handshake error: %w", err)
 		}
 	}
@@ -129,18 +129,29 @@ func clientDial(protocol, addr string, timeout time.Duration, options *Options) 
 }
 
 // TlsHandshake tls handshake on a plain connection
-func TlsHandshake(conn net.Conn, addr string) (net.Conn, error) {
+func TlsHandshake(conn net.Conn, addr string, timeout time.Duration) (net.Conn, error) {
 	colonPos := strings.LastIndex(addr, ":")
 	if colonPos == -1 {
 		colonPos = len(addr)
 	}
 	hostname := addr[:colonPos]
 
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
+
 	tlsConn := tls.Client(conn, &tls.Config{
 		InsecureSkipVerify: true,
 		ServerName:         hostname,
 	})
-	if err := tlsConn.Handshake(); err != nil {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		conn.Close()
 		return nil, err
 	}

--- a/conn.go
+++ b/conn.go
@@ -123,7 +123,7 @@ func clientDial(protocol, addr string, timeout time.Duration, options *Options) 
 			return nil, err
 		}
 		tlsConn := tls.Client(conn, tlsConfig)
-		return tlsConn, tlsConn.Handshake()
+		return tlsConn, tlsConn.HandshakeContext(ctx)
 	}
 	return tls.Dial("tcp", addr, tlsConfig)
 }


### PR DESCRIPTION
The following PR fixes a bug when requesting "https" targets.

In the current implementation the tlsConn does not respect the timeout settings once the connection is established. 
The function *tlsConn.Handshake()* will wait until the server sends data or closes the connection.

This means a single tarpit server, which sends TCP-Alive packets but no data, is able to halt rawhttp clients.


### Simple test
The following snippet creates a server which holds the connection open and a client with a timeout connecting to the server. 
The server component can also be a netcat listener `nc -v -l -p 1337`.

```
2022/08/15 18:09:08 [c] request to https://127.0.0.1:1337
2022/08/15 18:09:08 [s] Starting srv on 127.0.0.1:1337
2022/08/15 18:09:08 [s] tarpitting 127.0.0.1:41670 for 1m30s
2022/08/15 18:10:39 [s] release 127.0.0.1:41670 from tarpit
2022/08/15 18:10:39 [c] finished
2022/08/15 18:10:39 took 90.087851282
```


```golang
package main

import(
	"log"
	"fmt"
	"time"
	"net"

	"github.com/projectdiscovery/rawhttp"
)

func main() {

	addr := "127.0.0.1:1337"
	sleep := 90 * time.Second
	timeout := 2 * time.Second 

	ln, err  := ListenAndServe(addr, sleep)
	if err != nil {
		log.Fatal(err)
	}
	defer ln.Close()

	// perform check 
	start := time.Now()
	Check(addr, timeout)
	took := time.Now().Sub(start)

	log.Println("took", took.Seconds())
}


func Check(addr string, timeout time.Duration)(err error){

	options := rawhttp.DefaultOptions
	options.Timeout = timeout
	client := rawhttp.NewClient(options)
	uri := fmt.Sprintf("https://%s",addr)

	log.Printf("[c] request to %s", uri)
	_, err = client.Get(uri)
	log.Printf("[c] finished")
	return 
}

// --[Server Components]--
func ListenAndServe(addr string, sleep time.Duration)(listener net.Listener, err error){
	listener, err  = net.Listen("tcp", addr)
	if err != nil {
		return 
	}
	go StartServer(listener, sleep)
	return 
}
func StartServer(ln net.Listener, sleep time.Duration){
	log.Println("[s] Starting srv on", ln.Addr())
	for {
		conn, err := ln.Accept()
		if err != nil {
			continue
		}
		go handleClientConn(conn, sleep)
	}
}
// tarpit function
func handleClientConn(conn net.Conn, sleepDur time.Duration) {
	defer conn.Close()
	log.Printf("[s] tarpitting %s for %s\n",conn.RemoteAddr(), sleepDur.String())

	time.Sleep(sleepDur)
	log.Printf("[s] release %s from tarpit\n", conn.RemoteAddr())
}
```