### PR TITLE
add ztls fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ rawhttp is a Go package for making HTTP requests in a raw way.
 - Forked and adapted from [https://github.com/gorilla/http](https://github.com/gorilla/http) and [https://github.com/valyala/fasthttp](https://github.com/valyala/fasthttp)
 - The original idea is inspired by [@tomnomnom/rawhttp](https://github.com/tomnomnom/rawhttp) work
 
+
+### ZTLS fallback support
+
+### ZTLS Fallback
+
+`rawhttp` by default fallbacks to using zcrypto when there is an error in TLS handshake (ex: ` insufficient security level` etc ). This is done to support older TLS versions and ciphers. This can be disabled by setting `rawhttp.DisableZtlsFallback` to `true` or by using `DISABLE_ZTLS_FALLBACK` environment variable. when falling back to ztls, `ChromeCiphers` are used
+
+
+
 # Example
 
 First you need to declare a `server`

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http/httputil"
+
+	"github.com/projectdiscovery/rawhttp"
+)
+
+var (
+	url   string
+	short bool
+)
+
+func main() {
+	flag.StringVar(&url, "url", "https://scanme.sh", "URL to fetch")
+	flag.BoolVar(&short, "short", false, "Skip printing http response body")
+	flag.Parse()
+
+	client := rawhttp.NewClient(rawhttp.DefaultOptions)
+	resp, err := client.Get(url)
+	if err != nil {
+		panic(err)
+	}
+	bin, err := httputil.DumpResponse(resp, !short)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(bin))
+}


### PR DESCRIPTION
### Proposed Changes

- follow up of https://github.com/projectdiscovery/retryablehttp-go/pull/100
- closes #148 
- adds simple example at examples/simple 


### Notes:
when fastdialer client is set fallback is not supported as DialWithZTLS in fastdialer does not implement cipher randomization 