### PR TITLE
add http2 version support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,10 @@ type Version struct {
 }
 
 func (v *Version) String() string {
-	return fmt.Sprintf("HTTP/%d.%d", v.Major, v.Minor)
+	if v.Major < 2 {
+		return fmt.Sprintf("HTTP/%d.%d", v.Major, v.Minor)
+	}
+	return fmt.Sprintf("HTTP/%d", v.Major)
 }
 
 var (

--- a/client/reader.go
+++ b/client/reader.go
@@ -43,13 +43,23 @@ func (r *reader) ReadVersion() (Version, error) {
 				major = int(int(c) - 0x30)
 			}
 		case 6:
-			if c != '.' {
+			// For HTTP/2 and HTTP/3 there is no any '.', just do nothing
+			if c != '.' && major == 1 {
 				return readVersionErr(pos, '.', c)
+			}
+			if c != ' ' && (major == 2 || major == 3) {
+				return readVersionErr(pos, ' ', c)
+			}
+			if c == ' ' && (major == 2 || major == 3) {
+				return Version{Major: major, Minor: minor}, nil
 			}
 		case 7:
 			switch c {
 			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 				minor = int(int(c) - 0x30)
+			case ' ':
+				// HTTP/2 case
+				minor = 0
 			}
 		case 8:
 			if c != ' ' {

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -15,6 +15,14 @@ type statusTest struct {
 	err        bool
 }
 
+type versionTest struct {
+	name    string
+	version string
+	major   int
+	minor   int
+	err     bool
+}
+
 func TestStatusCode(t *testing.T) {
 	tests := []statusTest{
 		{"redirect 301", "301\r\n", 301, false},
@@ -25,11 +33,35 @@ func TestStatusCode(t *testing.T) {
 		{"invalid string", "aaa ", 0, true},
 		{"number with status text", "1234 unknown", 1234, false},
 	}
+
 	for _, test := range tests {
-		r := reader{bufio.NewReader(strings.NewReader(test.statusLine))}
-		result, err := r.ReadStatusCode()
-		hasError := err != nil
-		require.Equal(t, test.err, hasError, err)
-		require.Equal(t, test.result, result)
+		t.Run(test.name, func(t *testing.T) {
+			r := reader{bufio.NewReader(strings.NewReader(test.statusLine))}
+			result, err := r.ReadStatusCode()
+			hasError := err != nil
+			require.Equal(t, test.err, hasError, err)
+			require.Equal(t, test.result, result)
+		})
+	}
+}
+
+func TestReadVersion(t *testing.T) {
+	tests := []versionTest{
+		{"HTTP/0.9", "HTTP/0.9 OK", 0, 9, false},
+		{"HTTP/1.0", "HTTP/1.0 OK", 1, 0, false},
+		{"HTTP/1.1", "HTTP/1.1 OK", 1, 1, false},
+		{"HTTP/2", "HTTP/2 OK", 2, 0, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := reader{bufio.NewReader(strings.NewReader(test.version))}
+			result, err := r.ReadVersion()
+			hasError := err != nil
+			require.Equal(t, test.err, hasError, err)
+			require.Equal(t, strings.TrimSuffix(test.version, " OK"), result.String())
+			require.Equal(t, test.major, result.Major)
+			require.Equal(t, test.minor, result.Minor)
+		})
 	}
 }


### PR DESCRIPTION
Hello ProjectDiscovery team, seam like we cant parse HTTP2 request from bytes or string because of version logic. I have the following usecase: 

1) I get this response from Burp:
```http
HTTP/2 200 OK
Server: nginx/1.17.9
Date: Sat, 30 Mar 2024 17:36:11 GMT
Content-Type: application/javascript; charset=utf-8
Access-Control-Allow-Origin: *
Cache-Control: public, max-age=31556952
Etag: W/"af07e301570ab6511cd61c64c4fb822c"
Expires: Sun, 30 Mar 2025 23:20:38 GMT
Last-Modified: Fri, 15 Mar 2024 13:33:33 GMT
```

And just want to parse it this way:
```go
type nullWriterReader struct {
	io.Reader
}

func (nw nullWriterReader) Write(p []byte) (n int, err error) {
	return len(p), nil
}

...
// data - is gziped Response
if reader, err = gzip.NewReader(bytes.NewReader(data)); err != nil {
		c.JSON(errors.BadRequestError(err))
		return
}

rw := nullWriterReader{reader}
client := client.NewClient(rw)
res, err := client.ReadResponse(false)
```

`ReadResponse` return error because it doesn't know about HTTP/2 can be without minor version then calling `ReadVersion()`. My commit should help solve this case