### PR TITLE
fix: skip duplicate HTTP status lines in ReadResponse

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -124,12 +124,30 @@ func (c *client) WriteRequest(req *Request) error {
 	return c.WriteBody(req.Body)
 }
 
+// isStatusLine reports whether line looks like an HTTP status line
+// (e.g. "HTTP/1.0 200 OK"). It is used to skip duplicate status lines
+// emitted by some non-compliant servers.
+func isStatusLine(line []byte) bool {
+	return len(line) >= 5 && string(line[:5]) == "HTTP/"
+}
+
 // ReadResponse unmarshalls a HTTP response.
 func (c *client) ReadResponse(forceReadAll bool) (*Response, error) {
 	version, code, msg, err := c.ReadStatusLine()
 	var headers []Header
 	if err != nil {
 		return nil, fmt.Errorf("ReadStatusLine: %v", err)
+	}
+	// Some non-compliant servers (e.g. certain embedded devices) repeat the
+	// status line one or more times before the actual headers. Skip any such
+	// duplicate status lines so that header parsing succeeds.
+	for {
+		peeked, peekErr := c.Peek(5)
+		if peekErr != nil || !isStatusLine(peeked) {
+			break
+		}
+		// Discard the entire duplicate status line (read until newline).
+		_, _ = c.ReadBytes('\n')
 	}
 	for {
 		var key, value string

--- a/client/client.go
+++ b/client/client.go
@@ -124,11 +124,16 @@ func (c *client) WriteRequest(req *Request) error {
 	return c.WriteBody(req.Body)
 }
 
+// maxDuplicateStatusLines bounds how many repeated status lines we are willing
+// to discard, so a misbehaving (or malicious) server streaming "HTTP/..." lines
+// indefinitely cannot keep us looping.
+const maxDuplicateStatusLines = 8
+
 // isStatusLine reports whether line looks like an HTTP status line
 // (e.g. "HTTP/1.0 200 OK"). It is used to skip duplicate status lines
 // emitted by some non-compliant servers.
 func isStatusLine(line []byte) bool {
-	return len(line) >= 5 && string(line[:5]) == "HTTP/"
+	return bytes.HasPrefix(line, []byte("HTTP/"))
 }
 
 // ReadResponse unmarshalls a HTTP response.
@@ -141,13 +146,15 @@ func (c *client) ReadResponse(forceReadAll bool) (*Response, error) {
 	// Some non-compliant servers (e.g. certain embedded devices) repeat the
 	// status line one or more times before the actual headers. Skip any such
 	// duplicate status lines so that header parsing succeeds.
-	for {
+	for i := 0; i < maxDuplicateStatusLines; i++ {
 		peeked, peekErr := c.Peek(5)
 		if peekErr != nil || !isStatusLine(peeked) {
 			break
 		}
 		// Discard the entire duplicate status line (read until newline).
-		_, _ = c.ReadBytes('\n')
+		if _, err := c.ReadBytes('\n'); err != nil {
+			break
+		}
 	}
 	for {
 		var key, value string

--- a/client/reader_test.go
+++ b/client/reader_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bufio"
+	"io"
 	"strings"
 	"testing"
 
@@ -64,4 +65,31 @@ func TestReadVersion(t *testing.T) {
 			require.Equal(t, test.minor, result.Minor)
 		})
 	}
+}
+
+// readWriterStub wraps a strings.Reader to satisfy io.ReadWriter (writes are no-ops).
+type readWriterStub struct{ *strings.Reader }
+
+func (readWriterStub) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestReadResponseDuplicateStatusLines(t *testing.T) {
+	// Some non-compliant embedded devices (e.g. Grandstream HT801) emit the
+	// HTTP status line twice before the headers. rawhttp must not error on this.
+	raw := "HTTP/1.0 200 OK\r\nHTTP/1.0 200 OK\r\nContent-Type: text/html\r\nContent-Length: 5\r\n\r\nhello"
+	c := NewClient(readWriterStub{strings.NewReader(raw)})
+	resp, err := c.ReadResponse(false)
+	require.NoError(t, err, "ReadResponse must not fail on duplicate status lines")
+	require.Equal(t, 200, resp.Status.Code)
+	body, _ := io.ReadAll(resp.Body)
+	require.Equal(t, "hello", string(body))
+}
+
+func TestReadResponseTripleStatusLines(t *testing.T) {
+	// Also handle three consecutive status lines.
+	raw := "HTTP/1.0 200 OK\r\nHTTP/1.0 200 OK\r\nHTTP/1.0 200 OK\r\nX-Custom: test\r\n\r\n"
+	c := NewClient(readWriterStub{strings.NewReader(raw)})
+	resp, err := c.ReadResponse(false)
+	require.NoError(t, err, "ReadResponse must not fail on triple status lines")
+	require.Equal(t, 200, resp.Status.Code)
+	require.Equal(t, "test", resp.Headers[0].Value)
 }


### PR DESCRIPTION
## Problem

Some non-compliant servers (e.g. Grandstream HT801 firmware 1.0.13.7) emit the HTTP status line more than once before actual headers:

```
HTTP/1.0 200 OK\r\n
HTTP/1.0 200 OK\r\n   ← duplicate
Content-Type: text/html\r\n
\r\n
```

`ReadHeader()` splits on `:`. A repeated status line has no `:`, so parsing fails with:

```
malformed MIME header: missing colon: "HTTP/1.0 200 OK"
```

This error propagates to Nuclei as a fatal request error **even under `unsafe: true`**, preventing matchers from ever running.

## Fix

After reading the first status line in `ReadResponse()`, peek ahead and discard any additional lines that start with `HTTP/` before entering the header-reading loop. The change is minimal (< 15 lines) and touches only the one code path.

## Tests

Two new regression tests added to `client/reader_test.go`:
- `TestReadResponseDuplicateStatusLines` — double status line with a body
- `TestReadResponseTripleStatusLines` — triple status line

All existing tests continue to pass (`go test ./...`).

## Related

- Fixes #541
- Related nuclei issue: projectdiscovery/nuclei#7363